### PR TITLE
THVC-15689: Bump action runtime to Node.js 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
     description: 'Name of the labels that should be limited, provide multiples separated by commas'
     required: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'
 branding:
   icon: 'shield'


### PR DESCRIPTION
## Summary
- Switches `action.yml` runtime from `node20` (deprecated by GitHub Actions starting June 2026) to `node24` (jira: [THVC-15689](https://telushealth.atlassian.net/browse/THVC-15689))
- Required Actions Runner version: ≥ `v2.327.1` (GitHub-hosted runners are well past this; no AkiraMD self-hosted runners use this action)
- Dependencies (`@actions/core@1.11.1`, `@actions/github@6.0.1`) already support Node 24; `dist/index.js` unchanged after rebuild
- No source / test changes

## Release plan
After this PR is merged, tag a new release (e.g. `v2.1.0` and update the floating `v2`) so consumers can pin to the Node 24 build. Homer's `pr-limit.yml` will then be bumped in [AkiraMD/homer#9691](https://github.com/AkiraMD/homer/pull/9691).

## Test plan
- [ ] PR-limit workflow continues to function when invoked from a downstream repo (homer / monorail) after the new release tag is applied

[THVC-15689]: https://telushealth.atlassian.net/browse/THVC-15689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ